### PR TITLE
Changes to fix the vm-auth-key expiry issue

### DIFF
--- a/terraform/vmseries/management-vpc.auto.tfvars
+++ b/terraform/vmseries/management-vpc.auto.tfvars
@@ -62,5 +62,5 @@ panorama = {
   private_ips       = ["10.4.1.100"]
   security_group    = "panorama-sg"
   instance_type     = "m5.2xlarge"
-  ami               = "ami-0f1a372841f68f319"
+  ami               = "ami-05e891ec5e4cbd76f"
 }

--- a/terraform/vmseries/security-vpc.auto.tfvars
+++ b/terraform/vmseries/security-vpc.auto.tfvars
@@ -199,7 +199,7 @@ firewall-bootstrap_options = {
   "type"                = "dhcp-client"
   "tplname"             = "VM-tempstack"
   "dgname"              = "VM-DG"
-  "vm-auth-key"         = "410447188942721"
+  "vm-auth-key"         = "190346255173364"
 }
 
 firewall-interfaces = [


### PR DESCRIPTION
## Description

The vm-auth-key on the Panorama had expired and so the VM-Series firewall was not able to attach to the Panorama. The changes in this commit will replace the expired vm-auth-key with a new one. No update required in the documentation.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
